### PR TITLE
Add MongoDB encryption option

### DIFF
--- a/source/api_v2_instance_resources.rst
+++ b/source/api_v2_instance_resources.rst
@@ -105,6 +105,8 @@ Create a new instance
 
       Zones available: US-East-IAD3, US-West, EU-London, AP-HongKong, US-Chicago, AP-Sydney, and US-Dallas.
 
+      Encryption: Either True or False for encryption at rest (must be of boolean type).
+
    **redis**:
       Plans available: 500, 1000, 2500, 5000, 10000, 20000, 50000, 75000, and 100000.
 


### PR DESCRIPTION
For folks who create instances using our API:

```
POST /v2/instances/ HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 146
Content-Type: application/json
Host: sjc-api.objectrocket.com
User-Agent: HTTPie/0.9.2
X-Auth-Token:  IjliMTliZDQyZmE4MTRkYzNiNGE2N2YyYTc2YzdjMDUwIg.CUDTrQ.Fn1ovZNC0kldMiijfJJBaNupRTU

{
    "encryption": true,
    "name": "TESTTEST",
    "plan": 5,
    "service": "mongodb",
    "type": "mongodb_sharded",
    "version": "2.6.10",
    "zone": "US-East-IAD1"
}
```